### PR TITLE
Addressing #19 (Fusion stuck with empty fusion function file)

### DIFF
--- a/src/generators/SemanticFusion/SemanticFusion.py
+++ b/src/generators/SemanticFusion/SemanticFusion.py
@@ -14,7 +14,9 @@ class SemanticFusion(Generator):
         self.config_file = self.args.fusionfun
         self.oracle = self.args.oracle
         self.templates = {}
+        # print("Parsing mrs...",flush=True)
         self._parse_mrs()
+        # print("Parsing mrs...[DONE]",flush=True)
 
         if not self.oracle:
             print("ERROR: No oracle {sat,unsat} specified")
@@ -85,21 +87,18 @@ class SemanticFusion(Generator):
 
         return formula
     
-#     def _add_seedinfo(self,formula):
-        # formula.commands = [Comment(self.seed2)] + formula.commands
-        # formula.commands = [Comment(self.seed1)] + formula.commands
-        # return formula
-
 
     def generate(self):
-        is_fusion = True
+        skip_seed = True
         if self.formula1.free_var_occs == [] and self.formula2.free_var_occs == []:
-            is_fusion = False
+            skip_seed = True 
+
         formula1, formula2 = copy.deepcopy(self.formula1), copy.deepcopy(self.formula2)
         formula1.prefix_vars("scr1_")
         formula2.prefix_vars("scr2_")
+
         triplets = random_var_triplets(formula1.global_vars, formula2.global_vars, self.templates)
         if not triplets:
             is_fusion = False
         fused = self.fuse(formula1, formula2, triplets)
-        return fused, is_fusion
+        return fused, True, skip_seed 

--- a/src/generators/TypeAwareOpMutation.py
+++ b/src/generators/TypeAwareOpMutation.py
@@ -76,4 +76,4 @@ class TypeAwareOpMutation(Generator):
                     success = True
                     op_occ.op = replacee
                     break
-        return self.formula, success 
+        return self.formula, success, False

--- a/src/modules/Fuzzer.py
+++ b/src/modules/Fuzzer.py
@@ -93,10 +93,11 @@ class Fuzzer:
             for _ in range(self.args.iterations):
                 if not self.args.quiet:
                     self.statistic.printbar()
-                formula, success = self.generator.generate()
+                formula, success, skip_seed = self.generator.generate()
                 if not success: continue
                 if not self.test(formula): break
                 self.statistic.mutants += 1
+                if skip_seed: break
 
 
     def create_testbook(self, formula):


### PR DESCRIPTION
**Issue:**
 When the triplets for the two are empty lists (i.e. there are no suitable fusion functions for the two seed formulas), then the generator for fusion does simple concatenation but returns the fusion to be unsuccessful which is expected behavior. Since unsucessful generations are not counted by the statistic, it looks like fusion got stuck. 
 
 **Solution:**
Introduce a third parameter `skip_seed` for the generator to indicate that the fuzzer should go ahead with the next seed pair.