### PR TITLE
[BV] add remaining variants of LT and GT operators

### DIFF
--- a/yinyang/src/parsing/Typechecker.py
+++ b/yinyang/src/parsing/Typechecker.py
@@ -42,8 +42,8 @@ from yinyang.src.parsing.Types import (
     STR_REPLACE_RE_ALL, STR_TO_CODE, STR_TO_INT, STR_TO_RE, STR_FROM_CODE,
     STR_FROM_INT, STR_IS_DIGIT, RE_RANGE, SELECT, STORE, BV_CONCAT, BVNOT,
     BVNEG, BVAND, BVOR, BVXOR, BVADD, BVSUB, BVMUL, BVUDIV, BVUREM, BVSHL,
-    BV_EXTRACT, BV_ZERO_EXTEND, BV_SIGN_EXTEND, BVLSHR, BVASHR, BVSDIV, BVULT,
-    BVULE, BVSLT, BVSGT, FP_ABS, FP_NEG, FP_ADD, FP_SUB, FP_MUL, FP_DIV,
+    BV_EXTRACT, BV_ZERO_EXTEND, BV_SIGN_EXTEND, BVLSHR, BVASHR, BVSDIV, BVULT, BVUGT,
+    BVULE, BVUGE, BVSLT, BVSGT, BVSGE, BVSLE, FP_ABS, FP_NEG, FP_ADD, FP_SUB, FP_MUL, FP_DIV,
     FP_SQRT, FP_REM, FP_ROUND_TO_INTEGRAL, FP_NORMAL, FP_ISSUBNORMAL,
     FP_IS_ZERO, FP_ISINFINITE, FP_ISNAN, FP_ISNEGATIVE, FP_ISPOSITIVE, FP_LEQ,
     FP_LT, FP_GEQ, FP_GT, FP_EQ, FP_MIN, FP_MAX, FP_FMA, TO_FP_UNSIGNED, TO_FP
@@ -79,7 +79,7 @@ class TypeCheckError(Exception):
             for term in subterm[1:]:
                 s += term.__str__() + " "
             s += "]"
-            self.message += "faulty subterm:\t" + subterm.__str__() + "\n"
+            self.message += "faulty subterm:\t" + s + "\n"
         else:
             self.message += "faulty subterm:\t" + subterm.__str__() + "\n"
         self.message += "expected: \t" + str(expected) + "\n"
@@ -585,13 +585,18 @@ def typecheck_binary_bool_rt(expr, ctxt):
     (bvult (_ BitVec m) (_ BitVec m) Bool)
     (bvule (_ BitVec m) (_ BitVec m) Bool)
     (bvslt (_ BitVec m) (_ BitVec m) Bool)
+    (bvsle (_ BitVec m) (_ BitVec m) Bool)
+    (bvugt (_ BitVec m) (_ BitVec m) Bool)
+    (bvuge (_ BitVec m) (_ BitVec m) Bool)
+    (bvsgt (_ BitVec m) (_ BitVec m) Bool)
+    (bvsge (_ BitVec m) (_ BitVec m) Bool)
     """
     arg1, arg2 = expr.subterms[0], expr.subterms[1]
     t1 = typecheck_expr(expr.subterms[0], ctxt)
     t2 = typecheck_expr(expr.subterms[1], ctxt)
 
-    if not isinstance(arg1, BITVECTOR_TYPE) or\
-       not isinstance(arg2, BITVECTOR_TYPE):
+    if not isinstance(t1, BITVECTOR_TYPE) or\
+       not isinstance(t2, BITVECTOR_TYPE):
         raise TypeCheckError(
             expr, [arg1, arg2], [BITVECTOR_TYPE, BITVECTOR_TYPE], [t1, t2]
         )
@@ -618,7 +623,7 @@ def typecheck_bv_ops(expr, ctxt):
         BVSDIV,
     ]:
         return typecheck_bv_binary(expr, ctxt)
-    if expr.op in [BVULT, BVULE, BVSLT, BVSGT]:
+    if expr.op in [BVULT, BVUGT, BVULE, BVUGE, BVSLT, BVSGT, BVSLE, BVSGE]:
         return typecheck_binary_bool_rt(expr, ctxt)
 
 

--- a/yinyang/src/parsing/Types.py
+++ b/yinyang/src/parsing/Types.py
@@ -236,7 +236,12 @@ BVASHR = "bvashr"
 BVULT = "bvult"
 BVULE = "bvule"
 BVSLT = "bvslt"
+BVUGT = "bvugt"
+BVUGE = "bvuge"
 BVSGT = "bvsgt"
+BVSLT = "bvslt"
+BVSLE = "bvsle"
+BVSGE = "bvsge"
 BVSDIV = "bvsdiv"
 
 
@@ -256,8 +261,13 @@ BV_OPS = [
     BVASHR,
     BVLSHR,
     BVULT,
+    BVUGT,
     BVULE,
+    BVUGE,
     BVSLT,
+    BVSGT,
+    BVSLE,
+    BVSGE,
     BVSGT,
     BVSDIV,
 ]


### PR DESCRIPTION
Added support `BVUGT, BVUGE, BVSGE, BVSLE`. I tested a bit ad-hoc with:

```bash
#!/usr/bin/env bash
for f in path-to-semantic-fusion-seeds/BV/sat/*.smt2; do
  cp $f tests/unit/test.smt2;
  python -m unittest -k large tests/RunUnitTests.py;
done
git checkout tests/unit/test.smt2
```

and they all pass, same for `BV/unsat/`. I did not wait for `QF_BV` to finish, but the first few hundred worked fine.