### PR TITLE
Allow multiple constants c to appear in fusion functions 

### DIFF
--- a/docs/fusion.rst
+++ b/docs/fusion.rst
@@ -58,14 +58,14 @@ The configuration file ``yinyang/config/fusion_functions.txt`` specifies fusion 
 
 .. code-block:: text 
 
-    #begin  
+    #begin
     <declaration of x>
     <declaration of y>
     <declaration of z>
-    [<declaration of c>]
+    [<declaration of c_i>*]
     <assert fusion function>
-    <assert inversion function> 
-    <assert inversion function> 
+    <assert inversion function>
+    <assert inversion function>
     #end
 
 **Example:**
@@ -75,14 +75,16 @@ The following code shows schematically fusion and inversion are described in ``y
 .. code-block:: text 
 
     #begin
-    (declare-const x Int)
-    (declare-const y Int)
-    (declare-const z Int)
-    (declare-const c Int)
-    (assert (= z (+ (+ x y) c)))
-    (assert (= x (- (- z y) c)))
-    (assert (= y (- (- z x) c)))
+    (declare-const z Real)
+    (declare-const y Real)
+    (declare-const x Real)
+    (declare-const c Real)
+    (declare-const c1 Real)
+    (assert (= z (* (- (- y c) x) c1)))
+    (assert (= y (+ (+ (/ z c1) x) c)))
+    (assert (= x (- (- y c) (/ z c1))))
     #end
 
 
-The example realizes a fusion function for integer variables.  First, the variables x,y,z are declared. Variable c will be substituted by a random but fixed integer constant. Then fusion function :math:`z = f(x,y) =  x + y + c` is defined in the first assert block. Its corresponding inversion functions for x and y are described in the second and third asserts.     
+
+The example realizes a fusion function for integer variables.  First, the variables x,y,z are declared. Variables c_i will be substituted by a random but fixed real constant each. Then fusion function :math:`z = f(x, y) = ((y - c) - x) * c1` is defined in the first assert block. Its corresponding inversion functions for x and y are described in the second and third asserts.     

--- a/yinyang/src/core/Fuzzer.py
+++ b/yinyang/src/core/Fuzzer.py
@@ -78,7 +78,7 @@ MAX_TIMEOUTS = 32
 class Fuzzer:
     def __init__(self, args, strategy):
         self.args = args
-        self.currentseeds = ""
+        self.currentseeds = []
         self.strategy = strategy
         self.statistic = Statistic()
         self.generator = None
@@ -96,7 +96,7 @@ class Fuzzer:
             logging.debug("Skip invalid seed: exceeds max file size")
             return None, None
 
-        self.currentseeds = pathlib.Path(seed).stem
+        self.currentseeds.append(pathlib.Path(seed).stem)
         script, glob = parse_file(seed, silent=True)
 
         if not script:
@@ -112,6 +112,7 @@ class Fuzzer:
         seed = seeds.pop(random.randrange(len(seeds)))
         logging.debug("Processing seed " + seed)
         self.statistic.total_seeds += 1
+        self.currentseeds = []
         return self.process_seed(seed)
 
     def get_script_pair(self, seeds):
@@ -120,6 +121,7 @@ class Fuzzer:
         seed2 = seed[1]
         logging.debug("Processing seeds " + seed1 + " " + seed2)
         self.statistic.total_seeds += 2
+        self.currentseeds = []
         script1, glob1 = self.process_seed(seed1)
         script2, glob2 = self.process_seed(seed2)
         return script1, glob1, script2, glob2
@@ -211,7 +213,7 @@ class Fuzzer:
         testbook = []
         testcase = "%s/%s-%s-%s.smt2" % (
             self.args.scratchfolder,
-            escape(self.currentseeds),
+            escape("-".join(self.currentseeds)),
             self.name,
             random_string(),
         )
@@ -379,7 +381,7 @@ class Fuzzer:
             self.args.bugsfolder,
             bugtype,
             plain_cli,
-            escape(self.currentseeds),
+            escape("-".join(self.currentseeds)),
             random_string(),
         )
         try:
@@ -391,7 +393,7 @@ class Fuzzer:
             self.args.bugsfolder,
             bugtype,
             plain_cli,
-            escape(self.currentseeds),
+            escape("-".join(self.currentseeds)),
             random_string(),
         )
         with open(logpath, "w") as log:
@@ -419,7 +421,7 @@ class Fuzzer:
             self.args.bugsfolder,
             bugtype,
             plain_cli,
-            escape(self.currentseeds),
+            escape("-".join(self.currentseeds)),
             random_string(),
         )
         try:
@@ -432,7 +434,7 @@ class Fuzzer:
             self.args.bugsfolder,
             bugtype,
             plain_cli,
-            escape(self.currentseeds),
+            escape("-".join(self.currentseeds)),
             random_string(),
         )
         with open(logpath, "w") as log:

--- a/yinyang/src/mutators/SemanticFusion/SemanticFusion.py
+++ b/yinyang/src/mutators/SemanticFusion/SemanticFusion.py
@@ -90,7 +90,6 @@ class SemanticFusion(Mutator):
                 self.templates[sort].append(template)
 
     def fuse(self, formula1, formula2, triplets):
-
         fusion_vars = []
         fusion_constr = []
         for triplet in triplets:
@@ -120,7 +119,6 @@ class SemanticFusion(Mutator):
         else:
             formula = conjunction(formula1, formula2)
         add_var_decls(formula, fusion_vars)
-
         return formula
 
     def mutate(self):

--- a/yinyang/src/mutators/SemanticFusion/VariableFusion.py
+++ b/yinyang/src/mutators/SemanticFusion/VariableFusion.py
@@ -22,11 +22,15 @@
 
 import random
 import copy
+import re
 import string
 
 from yinyang.src.parsing.Ast import (
     Const, Var, Expr, Assert, DeclareConst, DeclareFun, Script
 )
+
+
+constant_name_pattern = re.compile(r"^c[0-9]*$")
 
 
 def gen_random_string(length):
@@ -54,6 +58,34 @@ def get_last_assert_idx(template):
     last_idx = len(template.commands)
     for i, cmd in enumerate(template.commands):
         if isinstance(cmd, Assert):
+            last_idx = i
+
+    return last_idx
+
+
+def get_first_constant_idx(template):
+    """
+    Finds first constant index in the template or -1 if none found.
+    :template:
+    :returns: returns index of first constant and -1 if there is no constant
+    """
+    for idx, decl in enumerate(template.commands):
+        if not isinstance(decl, DeclareConst):
+            break
+        if constant_name_pattern.match(decl.symbol) != None:
+            return idx
+    return -1
+
+
+def get_last_constant_idx(template):
+    """
+    Finds last constant index in the template or -1 if none found.
+    :template:
+    :returns: returns index of last constant and -1 if there is no constant
+    """
+    last_idx = -1
+    for i, decl in enumerate(template.commands):
+        if isinstance(decl, DeclareConst) and constant_name_pattern.match(decl.symbol) != None:
             last_idx = i
 
     return last_idx
@@ -116,14 +148,17 @@ def fill_template(x, y, template, var_type):
     z = Var(x + "_" + y + "_fused", var_type)
 
     # Detect whether template includes random variable c
-    random_constant_idx = get_constant_idx(template)
-    if random_constant_idx != -1:
-        declare_const = template.commands[random_constant_idx]
-        const_type = declare_const.sort
-        const_expr = get_constant_value(declare_const)
+    first_random_constant_idx = get_first_constant_idx(template)
+    if first_random_constant_idx != -1:
+        last_random_constant_idx = get_last_constant_idx(template)
+        assert first_ass_idx == last_random_constant_idx + 1
+        for i in range(first_random_constant_idx, last_random_constant_idx + 1):
+            declare_const = template.commands[i]
+            const_type = declare_const.sort
+            const_expr = get_constant_value(declare_const)
 
-        for ass in filled_template.commands[first_ass_idx:]:
-            ass.term.substitute(Var("c", const_type), const_expr)
+            for ass in filled_template.commands[first_ass_idx:]:
+                ass.term.substitute(Var(declare_const.symbol, const_type), const_expr)
 
     # Bind occurrences x,y to template
     for ass in filled_template.commands[first_ass_idx:]:
@@ -138,20 +173,14 @@ def inv_x(template):
     """
     :returns: inversion function term for variable occurrence x
     """
-    if get_constant_idx(template) != -1:
-        return template.commands[5].term.subterms[1]
-
-    return template.commands[4].term.subterms[1]
+    return template.commands[-2].term.subterms[1]
 
 
 def inv_y(template):
     """
     :returns: inversion function term for variable occurrence y
     """
-    if get_constant_idx(template) != -1:
-        return template.commands[6].term.subterms[1]
-
-    return template.commands[5].term.subterms[1]
+    return template.commands[-1].term.subterms[1]
 
 
 def fusion_contraints(template, var_type):


### PR DESCRIPTION
Together with Lucas Weitzendorf, I am working at a fusion functions generator for our AST project.

Our generator can build very long funsion functions and their inversions and we would like to allow multiple constants to appear within the same block. This PR allow such specifications (see below for the format description) and is retro compatible. 

I rely here on the naming convention (constant names are in the format `c[0-9]*`) as I have seen this is already practically used now.

The new proposed format is:
```
#begin
<declaration of x>
<declaration of y>
<declaration of z>
[<declaration of c_i>*]
<assert fusion function>
<assert inversion function>
<assert inversion function>
# end
```