### PR TITLE
Feat: --keep-seeds command line option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: ci 
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   tests:

--- a/docs/fusion.rst
+++ b/docs/fusion.rst
@@ -58,14 +58,14 @@ The configuration file ``yinyang/config/fusion_functions.txt`` specifies fusion 
 
 .. code-block:: text 
 
-    #begin  
+    #begin
     <declaration of x>
     <declaration of y>
     <declaration of z>
-    [<declaration of c>]
+    [<declaration of c_i>*]
     <assert fusion function>
-    <assert inversion function> 
-    <assert inversion function> 
+    <assert inversion function>
+    <assert inversion function>
     #end
 
 **Example:**
@@ -75,14 +75,16 @@ The following code shows schematically fusion and inversion are described in ``y
 .. code-block:: text 
 
     #begin
-    (declare-const x Int)
-    (declare-const y Int)
-    (declare-const z Int)
-    (declare-const c Int)
-    (assert (= z (+ (+ x y) c)))
-    (assert (= x (- (- z y) c)))
-    (assert (= y (- (- z x) c)))
+    (declare-const x Real)
+    (declare-const y Real)
+    (declare-const z Real)
+    (declare-const c Real)
+    (declare-const c1 Real)
+    (assert (= z (* (- (- y c) x) c1)))
+    (assert (= x (- (- y c) (/ z c1))))
+    (assert (= y (+ (+ (/ z c1) x) c)))
     #end
 
 
-The example realizes a fusion function for integer variables.  First, the variables x,y,z are declared. Variable c will be substituted by a random but fixed integer constant. Then fusion function :math:`z = f(x,y) =  x + y + c` is defined in the first assert block. Its corresponding inversion functions for x and y are described in the second and third asserts.     
+
+The example realizes a fusion function for integer variables.  First, the variables x,y,z are declared. Variables c_i will be substituted by a random but fixed real constant each. Then fusion function :math:`z = f(x, y) = ((y - c) - x) * c1` is defined in the first assert block. Its corresponding inversion functions for x and y are described in the second and third asserts.     

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [metadata]
 name = yinyang
 version = 0.3.0
-author = Dominik Winterer, Chengyu Zhang, Jiwon Park, Zhendong Su
-author_email = dominik.winterer@inf.ethz.ch, dale.chengyu.zhang@gmail.com, jiwon.park@polytechnique.edu, ‎zhendong.su@inf.ethz.ch
+author = Dominik Winterer, Chengyu Zhang, Jiwon Park, Zhendong Su, Nicola Dardanis, Lucas Weitzendorf
+author_email = dominik.winterer@inf.ethz.ch, dale.chengyu.zhang@gmail.com, jiwon.park@polytechnique.edu, ‎zhendong.su@inf.ethz.ch, nicdard@gmail.com, lweitzendorf@gmail.com
 description = A fuzzing framework for SMT solvers
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/yinyang/config/YinyangHelptext.py
+++ b/yinyang/config/YinyangHelptext.py
@@ -136,6 +136,7 @@ options:
             file size limit on seed formula in bytes (default: 100000)
     -n, --no-log    disable logging
     -q, --quiet     do not print statistics and other output
+    -r, --randomize randomize processing order of the seeds
     -v, --version   show version number and exit
     -h, --help      show this help message and exit
 """

--- a/yinyang/src/base/ArgumentParser.py
+++ b/yinyang/src/base/ArgumentParser.py
@@ -188,6 +188,11 @@ def add_yinyang_args(parser, rootpath, current_dir):
         metavar="path_to_file",
         default=rootpath + "/yinyang/config/fusion_functions.txt",
     )
+    parser.add_argument(
+        "-r",
+        "--randomize",
+        action='store_true',
+    )
 
 
 def build_opfuzz_parser(current_dir, usage):

--- a/yinyang/src/base/ArgumentParser.py
+++ b/yinyang/src/base/ArgumentParser.py
@@ -79,6 +79,11 @@ def add_common_args(parser, rootpath, current_dir):
         default=current_dir + "/bugs",
     )
     parser.add_argument(
+        "-k"
+        "--keep-seeds",
+        action="store_true",
+    )
+    parser.add_argument(
         "-s",
         "--scratchfolder",
         metavar="path_to_folder",

--- a/yinyang/src/core/Fuzzer.py
+++ b/yinyang/src/core/Fuzzer.py
@@ -200,7 +200,8 @@ class Fuzzer:
                     break  # Continue to next seed.
 
                 self.statistic.mutants += 1
-                os.remove(scratchfile)
+                if not self.args.keep_seeds:
+                    os.remove(scratchfile)
 
             log_finished_generations(successful_gens, unsuccessful_gens)
         self.terminate()

--- a/yinyang/src/core/Fuzzer.py
+++ b/yinyang/src/core/Fuzzer.py
@@ -372,7 +372,7 @@ class Fuzzer:
 
                         log_soundness_trigger(self.args, iteration, path)
                         return False  # Stop testing.
-            os.remove(scratchfile)
+            # os.remove(scratchfile)
         return True  # Continue to next seed.
 
     def report(self, scratchfile, bugtype, cli, stdout, stderr):

--- a/yinyang/src/core/Fuzzer.py
+++ b/yinyang/src/core/Fuzzer.py
@@ -194,11 +194,13 @@ class Fuzzer:
                     log_skip_seed_mutator(self.args, i)
                     break  # Continue to next seed.
 
-                if not self.test(mutant, i + 1):  # Continue to next seed.
+                (mutate_further, scratchfile) = self.test(mutant, i + 1)
+                if not mutate_further:  # Continue to next seed.
                     log_skip_seed_test(self.args, i)
                     break  # Continue to next seed.
 
                 self.statistic.mutants += 1
+                os.remove(scratchfile)
 
             log_finished_generations(successful_gens, unsuccessful_gens)
         self.terminate()
@@ -246,6 +248,7 @@ class Fuzzer:
 
         testbook = self.create_testbook(script)
         reference = None
+        scratchfile = None
         for testitem in testbook:
             solver_cli, scratchfile = testitem[0], testitem[1]
             solver = Solver(solver_cli)
@@ -255,7 +258,7 @@ class Fuzzer:
             )
 
             if self.max_timeouts_reached():
-                return False
+                return (False, scratchfile)
 
             # Match stdout and stderr against the crash list
             # (see yinyang/config/Config.py:27) which contains various
@@ -270,13 +273,13 @@ class Fuzzer:
                     self.statistic.effective_calls += 1
                     self.statistic.crashes += 1
                     path = self.report(
-                        scratchfile, "crash", solver_cli, stdout, stderr
+                        script, "crash", solver_cli, stdout, stderr
                     )
                     log_crash_trigger(path)
                 else:
                     self.statistic.duplicates += 1
                     log_duplicate_trigger()
-                return False  # Stop testing.
+                return (False, scratchfile)  # Stop testing.
             else:
 
                 # Check whether the solver call produced errors, e.g, related
@@ -295,7 +298,7 @@ class Fuzzer:
                         self.statistic.effective_calls += 1
                         self.statistic.crashes += 1
                         path = self.report(
-                            scratchfile, "segfault", solver_cli, stdout, stderr
+                            script, "segfault", solver_cli, stdout, stderr
                         )
                         log_segfault_trigger(self.args, path, iteration)
                         return False  # Stop testing.
@@ -336,7 +339,7 @@ class Fuzzer:
                         # For differential testing (opfuzz), the first solver
                         # is set as the reference, its result to be the oracle.
                         oracle = result
-                        reference = (solver_cli, scratchfile, stdout, stderr)
+                        reference = (solver_cli, stdout, stderr)
 
                     # Comparing with the oracle (yinyang) or with other
                     # non-erroneous solver runs (opfuzz) for soundness bugs.
@@ -352,7 +355,7 @@ class Fuzzer:
                             ref_stdout = reference[1]
                             ref_stderr = reference[2]
                             path = self.report_diff(
-                                scratchfile,
+                                script,
                                 "incorrect",
                                 ref_cli,
                                 ref_stdout,
@@ -366,16 +369,15 @@ class Fuzzer:
                             # Produce a bug report if the query result differs
                             # from the pre-set oracle (yinyang).
                             path = self.report(
-                                scratchfile, "incorrect", solver_cli,
+                                script, "incorrect", solver_cli,
                                 stdout, stderr
                             )
 
                         log_soundness_trigger(self.args, iteration, path)
-                        return False  # Stop testing.
-            # os.remove(scratchfile)
-        return True  # Continue to next seed.
+                        return (False, scratchfile)  # Stop testing.
+        return (True, scratchfile)  # Continue to next seed.
 
-    def report(self, scratchfile, bugtype, cli, stdout, stderr):
+    def report(self, script, bugtype, cli, stdout, stderr):
         plain_cli = plain(cli)
         # format: <solver><{crash,wrong,invalid_model}><seed>.<random-str>.smt2
         report = "%s/%s-%s-%s-%s.smt2" % (
@@ -386,7 +388,8 @@ class Fuzzer:
             random_string(),
         )
         try:
-            shutil.copy(scratchfile, report)
+            with open(report, "w") as report_writer:
+                report_writer.write(script.__str__())
         except Exception:
             logging.error("error: couldn't copy scratchfile to bugfolder.")
             exit(ERR_EXHAUSTED_DISK)
@@ -407,7 +410,7 @@ class Fuzzer:
 
     def report_diff(
         self,
-        scratchfile,
+        script,
         bugtype,
         ref_cli,
         ref_stdout,
@@ -426,7 +429,8 @@ class Fuzzer:
             random_string(),
         )
         try:
-            shutil.copy(scratchfile, report)
+            with open(report, "w") as report_writer:
+                report_writer.write(script.__str__())
         except Exception:
             logging.error("error: couldn't copy scratchfile to bugfolder.")
             exit(ERR_EXHAUSTED_DISK)

--- a/yinyang/src/core/Fuzzer.py
+++ b/yinyang/src/core/Fuzzer.py
@@ -78,7 +78,7 @@ MAX_TIMEOUTS = 32
 class Fuzzer:
     def __init__(self, args, strategy):
         self.args = args
-        self.currentseeds = ""
+        self.currentseeds = []
         self.strategy = strategy
         self.statistic = Statistic()
         self.generator = None
@@ -96,7 +96,7 @@ class Fuzzer:
             logging.debug("Skip invalid seed: exceeds max file size")
             return None, None
 
-        self.currentseeds = pathlib.Path(seed).stem
+        self.currentseeds.append(pathlib.Path(seed).stem)
         script, glob = parse_file(seed, silent=True)
 
         if not script:
@@ -112,6 +112,7 @@ class Fuzzer:
         seed = seeds.pop(random.randrange(len(seeds)))
         logging.debug("Processing seed " + seed)
         self.statistic.total_seeds += 1
+        self.currentseeds = []
         return self.process_seed(seed)
 
     def get_script_pair(self, seeds):
@@ -120,6 +121,7 @@ class Fuzzer:
         seed2 = seed[1]
         logging.debug("Processing seeds " + seed1 + " " + seed2)
         self.statistic.total_seeds += 2
+        self.currentseeds = []
         script1, glob1 = self.process_seed(seed1)
         script2, glob2 = self.process_seed(seed2)
         return script1, glob1, script2, glob2
@@ -211,7 +213,7 @@ class Fuzzer:
         testbook = []
         testcase = "%s/%s-%s-%s.smt2" % (
             self.args.scratchfolder,
-            escape(self.currentseeds),
+            escape("-".join(self.currentseeds)),
             self.name,
             random_string(),
         )
@@ -370,6 +372,7 @@ class Fuzzer:
 
                         log_soundness_trigger(self.args, iteration, path)
                         return False  # Stop testing.
+            os.remove(scratchfile)
         return True  # Continue to next seed.
 
     def report(self, scratchfile, bugtype, cli, stdout, stderr):
@@ -379,7 +382,7 @@ class Fuzzer:
             self.args.bugsfolder,
             bugtype,
             plain_cli,
-            escape(self.currentseeds),
+            escape("-".join(self.currentseeds)),
             random_string(),
         )
         try:
@@ -391,7 +394,7 @@ class Fuzzer:
             self.args.bugsfolder,
             bugtype,
             plain_cli,
-            escape(self.currentseeds),
+            escape("-".join(self.currentseeds)),
             random_string(),
         )
         with open(logpath, "w") as log:
@@ -419,7 +422,7 @@ class Fuzzer:
             self.args.bugsfolder,
             bugtype,
             plain_cli,
-            escape(self.currentseeds),
+            escape("-".join(self.currentseeds)),
             random_string(),
         )
         try:
@@ -432,7 +435,7 @@ class Fuzzer:
             self.args.bugsfolder,
             bugtype,
             plain_cli,
-            escape(self.currentseeds),
+            escape("-".join(self.currentseeds)),
             random_string(),
         )
         with open(logpath, "w") as log:

--- a/yinyang/src/core/FuzzerUtil.py
+++ b/yinyang/src/core/FuzzerUtil.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import random
 import re
 import pathlib
 
@@ -84,6 +85,8 @@ def get_seeds(args, strategy):
             seeds = [(args.PATH_TO_SEEDS[0], args.PATH_TO_SEEDS[1])]
         else:
             assert False
+        if args.randomize:
+            random.shuffle(seeds)
     else:
         assert False
 

--- a/yinyang/src/mutators/SemanticFusion/Util.py
+++ b/yinyang/src/mutators/SemanticFusion/Util.py
@@ -103,11 +103,11 @@ def disjunction(script1, script2):
 def type_var_map(global_vars):
     mapping = {}
     for var in global_vars:
-        if global_vars[var] not in mapping:
-            mapping[global_vars[var]] = [var]
+        if str(global_vars[var]) not in mapping:
+            mapping[str(global_vars[var])] = [var]
         else:
-            if var not in mapping[global_vars[var]]:
-                mapping[global_vars[var]].append(var)
+            if var not in mapping[str(global_vars[var])]:
+                mapping[str(global_vars[var])].append(var)
     return mapping
 
 
@@ -143,12 +143,13 @@ def random_var_triplets(global_vars1, global_vars2, templates):
     """
     m1, m2 = type_var_map(global_vars1), type_var_map(global_vars2)
     mapping = []
-    for t in templates:
-        if t not in m1:
+    for (t1, t2) in templates:
+        if t1 not in m1:
             continue
-        if t not in m2:
+        if t2 not in m2:
             continue
-        random_tuples = random_tuple_list(m1[t], m2[t])
+        random_tuples = random_tuple_list(m1[t1], m2[t2])
         for tup in random_tuples:
-            mapping.append((tup[0], tup[1], random.choice(templates[t]), t))
+            mapping.append(
+                (tup[0], tup[1], random.choice(templates[(t1, t2)])))
     return mapping

--- a/yinyang/src/mutators/SemanticFusion/VariableFusion.py
+++ b/yinyang/src/mutators/SemanticFusion/VariableFusion.py
@@ -73,7 +73,7 @@ def get_first_constant_idx(template):
     for idx, decl in enumerate(template.commands):
         if not isinstance(decl, DeclareConst):
             break
-        if constant_name_pattern.match(decl.symbol) != None:
+        if constant_name_pattern.match(decl.symbol) is not None:
             return idx
     return -1
 
@@ -86,7 +86,8 @@ def get_last_constant_idx(template):
     """
     last_idx = -1
     for i, decl in enumerate(template.commands):
-        if isinstance(decl, DeclareConst) and constant_name_pattern.match(decl.symbol) != None:
+        if isinstance(decl, DeclareConst) and \
+                constant_name_pattern.match(decl.symbol) is not None:
             last_idx = i
 
     return last_idx
@@ -138,7 +139,10 @@ def get_constant_value(declare_const):
 
     if isinstance(const_type, BITVECTOR_TYPE):
         length = const_type.bitwidth
-        return Const(f"#b{random.getrandbits(length):0{length}b}", type=const_type)
+        return Const(
+            f"#b{random.getrandbits(length):0{length}b}",
+            type=const_type,
+        )
 
 
 def fill_template(x, y, template):
@@ -157,7 +161,8 @@ def fill_template(x, y, template):
     if first_random_constant_idx != -1:
         last_random_constant_idx = get_last_constant_idx(template)
         assert first_ass_idx == last_random_constant_idx + 1
-        for i in range(first_random_constant_idx, last_random_constant_idx + 1):
+        for i in range(first_random_constant_idx,
+                       last_random_constant_idx + 1):
             declare_const = template.commands[i]
             const_type = declare_const.sort
             const_expr = get_constant_value(declare_const)
@@ -182,8 +187,8 @@ def x_sort(template):
     returns: returns the sort of variable x
     """
     if template.commands[0].symbol != 'x':
-        ValueError(
-            'Expected x variable declaration as first command in the fusion function.')
+        ValueError('Expected x variable declaration as first ' +
+                   'command in the fusion function.')
     return template.commands[0].sort
 
 
@@ -193,7 +198,8 @@ def y_sort(template):
     """
     if template.commands[1].symbol != 'y':
         ValueError(
-            'Expected y variable declaration as first command in the fusion function.')
+            'Expected y variable declaration as ' +
+            'second command in the fusion function.')
     return template.commands[1].sort
 
 
@@ -203,7 +209,8 @@ def z_sort(template):
     """
     if template.commands[2].symbol != 'z':
         ValueError(
-            'Expected z variable declaration as first command in the fusion function.')
+            'Expected z variable declaration as third ' +
+            'command in the fusion function.')
     return template.commands[2].sort
 
 

--- a/yinyang/src/parsing/Ast.py
+++ b/yinyang/src/parsing/Ast.py
@@ -203,9 +203,9 @@ class DeclareFun:
             "(declare-fun "
             + self.symbol
             + " ("
-            + self.input_sort
+            + str(self.input_sort)
             + ") "
-            + self.output_sort
+            + str(self.output_sort)
             + ")"
         )
 
@@ -257,7 +257,7 @@ class DefineConst:
             "(define-const "
             + self.symbol
             + " "
-            + self.sort
+            + str(self.sort)
             + " "
             + self.term.__str__()
             + ")"
@@ -278,7 +278,7 @@ class DefineFun:
             + " ("
             + self.sorted_vars
             + ") "
-            + self.sort
+            + str(self.sort)
             + " "
             + self.term.__str__()
             + ")"
@@ -304,7 +304,7 @@ class DefineFunRec:
             + " ("
             + s
             + ") "
-            + self.sort
+            + str(self.sort)
             + " "
             + self.term.__str__()
             + ")"
@@ -321,7 +321,7 @@ class FunDecl:
         s = self.sorted_vars[0]
         for svar in self.sorted_vars[1:]:
             s += " " + svar
-        return "(" + self.symbol + " (" + s + ") " + self.sort + ")"
+        return "(" + self.symbol + " (" + s + ") " + str(self.sort) + ")"
 
 
 class DefineFunsRec:

--- a/yinyang/src/parsing/AstVisitor.py
+++ b/yinyang/src/parsing/AstVisitor.py
@@ -119,7 +119,7 @@ class AstVisitor(SMTLIBv2Visitor):
             self.global_vars[var] = self.visitSort(ctx.sort()[0])
             decl = DeclareConst(
                 self.visitSymbol(ctx.symbol()[0]),
-                self.visitSort(ctx.sort()[0])
+                sort2type(self.visitSort(ctx.sort()[0]))
             )
             return decl
         if ctx.cmd_declareFun():


### PR DESCRIPTION
Add the command line option `--keep-seeds` (`-k`) with default value `True`. 
When set to `False`, scratch files will not be kept in the scratch folder after the Fuzzer executes, but the files will be created anyway.