### PR TITLE
Feat: --keep-seeds and --generate-functions command line option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,9 @@ jobs:
     - name: Spell check 
       run: |
         codespell --skip="Solver.py,SMTLIBv2*,*.g4,*.tokens,*.interp,*.smt2"
+    - name: code style and static analysis with flake 
+      run: |
+        bin/checkstyle.sh
     - name: Run Unittests
       run: |
         python -m unittest tests/RunUnitTests.py
@@ -51,9 +54,6 @@ jobs:
       run: |
         python tests/regression/issue42.py
         cd tests/regression && python scoping_bug.py
-    - name: code style and static analysis with flake 
-      run: |
-        bin/checkstyle.sh
     - name: pypi check  
       run: |
         tests/integration/misc/pypi.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,8 @@ jobs:
         pip install codespell
         python -m pip install flake8
         python -m pip install --upgrade pip 
-        python -m pip install antlr4-python3-runtime==4.9.2  
+        python -m pip install antlr4-python3-runtime==4.9.2 
+        python -m pip install ffg 
     - name: Spell check 
       run: |
         codespell --skip="Solver.py,SMTLIBv2*,*.g4,*.tokens,*.interp,*.smt2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ include_package_data = True
 packages = find:
 install_requires =
     antlr4-python3-runtime==4.9.2
-    ffg==0.1.0
+    ffg==0.1.1
 python_requires = >=3.6
 scripts =
     bin/yinyang

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ include_package_data = True
 packages = find:
 install_requires =
     antlr4-python3-runtime==4.9.2
+    ffg==0.1.0
 python_requires = >=3.6
 scripts =
     bin/yinyang

--- a/tests/unit/TestSemanticFusion.py
+++ b/tests/unit/TestSemanticFusion.py
@@ -32,6 +32,7 @@ sys.path.append("../../")
 class Mockargs:
     oracle = ""
     config = ""
+    generate_functions = 0
 
 
 class SemanticFusionTestCase(unittest.TestCase):

--- a/yinyang/config/OpfuzzHelptext.py
+++ b/yinyang/config/OpfuzzHelptext.py
@@ -157,6 +157,7 @@ options:
             set custom operator mutation config file
     -L <bytes>, --limit <bytes>
             file size limit on seed formula in bytes (default: 100000)
+    -k, --keep-mutants  do not delete scratch files
     -n, --no-log    disable logging
     -q, --quiet     do not print statistics and other output
     -v, --version   show version number and exit

--- a/yinyang/config/TypefuzzHelptext.py
+++ b/yinyang/config/TypefuzzHelptext.py
@@ -123,6 +123,7 @@ options:
             (default: yinyang/config/typefuzz_config.txt)
     -L <bytes>, --limit <bytes>
             file size limit on seed formula in bytes (default: 100000)
+    -k, --keep-mutants  do not delete scratch files
     -n, --no-log    disable logging
     -q, --quiet     do not print statistics and other output
     -v, --version   show version number and exit

--- a/yinyang/config/YinyangHelptext.py
+++ b/yinyang/config/YinyangHelptext.py
@@ -134,9 +134,10 @@ options:
             set custom fusion function file
     -L <bytes>, --limit <bytes>
             file size limit on seed formula in bytes (default: 100000)
-    -n, --no-log    disable logging
-    -q, --quiet     do not print statistics and other output
-    -r, --randomize randomize processing order of the seeds
-    -v, --version   show version number and exit
-    -h, --help      show this help message and exit
+    -k, --keep-mutants  do not delete scratch files
+    -n, --no-log        disable logging
+    -q, --quiet         do not print statistics and other output
+    -r, --randomize     randomize processing order of the seeds
+    -v, --version       show version number and exit
+    -h, --help          show this help message and exit
 """

--- a/yinyang/config/YinyangHelptext.py
+++ b/yinyang/config/YinyangHelptext.py
@@ -134,10 +134,13 @@ options:
             set custom fusion function file
     -L <bytes>, --limit <bytes>
             file size limit on seed formula in bytes (default: 100000)
-    -k, --keep-mutants  do not delete scratch files
-    -n, --no-log        disable logging
-    -q, --quiet         do not print statistics and other output
-    -r, --randomize     randomize processing order of the seeds
-    -v, --version       show version number and exit
-    -h, --help          show this help message and exit
+    -g <ffg>, --generate-functions <ffg>
+            dimension of the fusion functions to generate, if greater than 
+            0 do not take into account --config option. (default: 0)
+    -k, --keep-mutants          do not delete scratch file
+    -n, --no-log                disable logging
+    -q, --quiet                 do not print statistics and other output
+    -r, --randomize             randomize processing order of the seeds
+    -v, --version               show version number and exit
+    -h, --help                  show this help message and exit
 """

--- a/yinyang/src/base/ArgumentParser.py
+++ b/yinyang/src/base/ArgumentParser.py
@@ -79,7 +79,7 @@ def add_common_args(parser, rootpath, current_dir):
         default=current_dir + "/bugs",
     )
     parser.add_argument(
-        "-k"
+        "-k",
         "--keep-mutants",
         action="store_true",
     )

--- a/yinyang/src/base/ArgumentParser.py
+++ b/yinyang/src/base/ArgumentParser.py
@@ -194,6 +194,13 @@ def add_yinyang_args(parser, rootpath, current_dir):
         default=rootpath + "/yinyang/config/fusion_functions.txt",
     )
     parser.add_argument(
+        "-g",
+        "--generate-functions",
+        metavar="<ffg>",
+        default=0,
+        type=int,
+    )
+    parser.add_argument(
         "-r",
         "--randomize",
         action='store_true',

--- a/yinyang/src/base/ArgumentParser.py
+++ b/yinyang/src/base/ArgumentParser.py
@@ -79,6 +79,11 @@ def add_common_args(parser, rootpath, current_dir):
         default=current_dir + "/bugs",
     )
     parser.add_argument(
+        "-k"
+        "--keep-mutants",
+        action="store_true",
+    )
+    parser.add_argument(
         "-s",
         "--scratchfolder",
         metavar="path_to_folder",

--- a/yinyang/src/core/Fuzzer.py
+++ b/yinyang/src/core/Fuzzer.py
@@ -200,7 +200,8 @@ class Fuzzer:
                     break  # Continue to next seed.
 
                 self.statistic.mutants += 1
-                os.remove(scratchfile)
+                if not self.args.keep_seeds:
+                    os.remove(scratchfile)
 
             log_finished_generations(successful_gens, unsuccessful_gens)
         self.terminate()

--- a/yinyang/src/core/Fuzzer.py
+++ b/yinyang/src/core/Fuzzer.py
@@ -200,7 +200,7 @@ class Fuzzer:
                     break  # Continue to next seed.
 
                 self.statistic.mutants += 1
-                if not self.args.keep_seeds:
+                if not self.args.keep_mutants:
                     os.remove(scratchfile)
 
             log_finished_generations(successful_gens, unsuccessful_gens)

--- a/yinyang/src/mutators/SemanticFusion/SemanticFusion.py
+++ b/yinyang/src/mutators/SemanticFusion/SemanticFusion.py
@@ -133,9 +133,11 @@ class SemanticFusion(Mutator):
         formula1.prefix_vars("scr1_")
         formula2.prefix_vars("scr2_")
 
-        templates = generate_fusion_function_templates(formula1.global_vars,
-                                                       formula2.global_vars,
-                                                       self.generate_functions_size) \
+        templates = generate_fusion_function_templates(
+            formula1.global_vars,
+            formula2.global_vars,
+            self.generate_functions_size
+        ) \
             if self.generate_functions \
             else self.templates
 

--- a/yinyang/src/mutators/SemanticFusion/SemanticFusion.py
+++ b/yinyang/src/mutators/SemanticFusion/SemanticFusion.py
@@ -133,7 +133,6 @@ class SemanticFusion(Mutator):
         formula1.prefix_vars("scr1_")
         formula2.prefix_vars("scr2_")
 
-        # For now just create one formula for the type provided
         templates = generate_fusion_function_templates(formula1.global_vars,
                                                        formula2.global_vars,
                                                        self.generate_functions_size) \

--- a/yinyang/src/mutators/SemanticFusion/SemanticFusion.py
+++ b/yinyang/src/mutators/SemanticFusion/SemanticFusion.py
@@ -32,11 +32,11 @@ from yinyang.src.mutators.SemanticFusion.VariableFusion import (
     add_fusion_constraints,
     add_var_decls,
     canonicalize_script,
-    x_sort,
-    y_sort,
     z_sort
 )
 from yinyang.src.mutators.SemanticFusion.Util import (
+    generate_fusion_function_templates,
+    populate_template_map,
     random_var_triplets,
     disjunction,
     conjunction,
@@ -52,9 +52,12 @@ class SemanticFusion(Mutator):
         self.formula2 = canonicalize_script(formula2)
         self.args = args
         self.config = self.args.config
+        self.generate_functions = self.args.generate_functions > 0
+        self.generate_functions_size = self.args.generate_functions
         self.oracle = self.args.oracle
         self.templates = {}
-        self._parse_mrs()
+        if not self.generate_functions:
+            self._parse_mrs()
 
         if not self.oracle:
             print("error: No oracle {sat,unsat} specified")
@@ -83,15 +86,9 @@ class SemanticFusion(Mutator):
             if started:
                 curr.append(line)
 
-        for i, mr in enumerate(_mrs):
+        for _, mr in enumerate(_mrs):
             template, _ = parse_str(mr)
-            # Use the type information of x and y.
-            sort = (str(x_sort(template)), str(y_sort(template)))
-
-            if sort not in self.templates:
-                self.templates[sort] = [template]
-            else:
-                self.templates[sort].append(template)
+            populate_template_map(self.templates, template)
 
     def fuse(self, formula1, formula2, triplets):
         fusion_vars = []
@@ -136,8 +133,15 @@ class SemanticFusion(Mutator):
         formula1.prefix_vars("scr1_")
         formula2.prefix_vars("scr2_")
 
+        # For now just create one formula for the type provided
+        templates = generate_fusion_function_templates(formula1.global_vars,
+                                                       formula2.global_vars,
+                                                       self.generate_functions_size) \
+            if self.generate_functions \
+            else self.templates
+
         triplets = random_var_triplets(
-            formula1.global_vars, formula2.global_vars, self.templates
+            formula1.global_vars, formula2.global_vars, templates
         )
         fused = self.fuse(formula1, formula2, triplets)
         return fused, True, skip_seed

--- a/yinyang/src/mutators/SemanticFusion/Util.py
+++ b/yinyang/src/mutators/SemanticFusion/Util.py
@@ -34,7 +34,12 @@ from yinyang.src.parsing.Ast import (
     SMTLIBCommand,
 )
 from yinyang.src.parsing.Parse import parse_str
-from yinyang.src.parsing.Types import ARRAY_TYPE, BITVECTOR_TYPE, FP_TYPE, type2ffg
+from yinyang.src.parsing.Types import (
+    ARRAY_TYPE,
+    BITVECTOR_TYPE,
+    FP_TYPE,
+    type2ffg,
+)
 
 from ffg.gen import gen_configuration
 from ffg.gen.tree_generation import generate_tree

--- a/yinyang/src/mutators/SemanticFusion/Util.py
+++ b/yinyang/src/mutators/SemanticFusion/Util.py
@@ -20,8 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import io
 import random
 import itertools
+from yinyang.src.mutators.SemanticFusion.VariableFusion import x_sort, y_sort
 
 from yinyang.src.parsing.Ast import (
     Term,
@@ -31,6 +33,12 @@ from yinyang.src.parsing.Ast import (
     DeclareFun,
     SMTLIBCommand,
 )
+from yinyang.src.parsing.Parse import parse_str
+from yinyang.src.parsing.Types import ARRAY_TYPE, BITVECTOR_TYPE, FP_TYPE, type2ffg
+
+from ffg.gen import gen_configuration
+from ffg.gen.tree_generation import generate_tree
+from ffg.emitter.yinyang_emitter import emit_function
 
 
 def cvars(occs):
@@ -153,3 +161,65 @@ def random_var_triplets(global_vars1, global_vars2, templates):
             mapping.append(
                 (tup[0], tup[1], random.choice(templates[(t1, t2)])))
     return mapping
+
+
+def _type_list(global_vars):
+    """
+    Return a list of variable types that can be used to 
+    generate new fusion functions.
+    """
+    mapping = {}
+    for var in global_vars:
+        if isinstance(global_vars[var], ARRAY_TYPE) or \
+            isinstance(global_vars[var], FP_TYPE) or \
+                isinstance(global_vars[var], BITVECTOR_TYPE):
+            continue
+        if str(global_vars[var]) not in mapping:
+            mapping[str(global_vars[var])] = global_vars[var]
+    return mapping
+
+
+def populate_template_map(templates, template):
+    """
+    Given a template and a template map, insert this 
+    template inside the map using as index the tuple
+    containing the sorts of the input variables.
+    """
+    # Use the type information of x and y.
+    sort = (str(x_sort(template)), str(y_sort(template)))
+
+    if sort not in templates:
+        templates[sort] = [template]
+    else:
+        templates[sort].append(template)
+
+
+def generate_fusion_function_templates(global_vars1, global_vars2, size=25):
+    """
+    Create random variables mapping of variables from the seeds
+    and new fusion functions to fuse them. Returns the templates
+    used to perform the fuse step.
+    """
+    # Solve BitVec problem with a best effort approach:
+    # try to generate formulas until you get the right bitvector type.
+    tlist1 = _type_list(global_vars1)
+    tlist2 = _type_list(global_vars2)
+    templates = {}
+
+    for t1 in tlist1:
+        type1 = tlist1[t1]
+        for t2 in tlist2:
+            type2 = tlist2[t2]
+
+            theories = [type2ffg(type1), type2ffg(type2)]
+            gen_configuration.set_available_theories(theories)
+            operator_types = gen_configuration.get_theories()
+            root_type = random.choice(operator_types)
+            tree, _ = generate_tree(root_type, size, ['x', 'y'], 'z')
+            output = io.StringIO()
+            emit_function(tree, output, is_wrapped=False)
+
+            template, _ = parse_str(output.getvalue())
+            populate_template_map(templates, template)
+
+    return templates

--- a/yinyang/src/mutators/SemanticFusion/VariableFusion.py
+++ b/yinyang/src/mutators/SemanticFusion/VariableFusion.py
@@ -28,7 +28,7 @@ import string
 from yinyang.src.parsing.Ast import (
     Const, Var, Expr, Assert, DeclareConst, DeclareFun, Script
 )
-from yinyang.src.parsing.Types import BITVECTOR_TYPE
+from yinyang.src.parsing.Types import BITVECTOR_TYPE, BOOLEAN_TYPE, INTEGER_TYPE, REAL_TYPE, STRING_TYPE
 
 
 constant_name_pattern = re.compile(r"^c[0-9]*$")
@@ -114,7 +114,7 @@ def get_constant_value(declare_const):
     """
     const_type = declare_const.sort
 
-    if const_type == "Int":
+    if const_type == INTEGER_TYPE:
         r = random.randint(-1000, 1000)
         if r < 0:
             return Expr(op="-",
@@ -122,7 +122,7 @@ def get_constant_value(declare_const):
         else:
             return Const(name=str(r), type=const_type)
 
-    if const_type == "Real":
+    if const_type == REAL_TYPE:
         r = round(random.uniform(-1000, 1000), 5)
         if r < 0:
             return Expr(op="-",
@@ -130,10 +130,10 @@ def get_constant_value(declare_const):
         else:
             return Const(str(r), type=const_type)
 
-    if const_type == "Bool":
+    if const_type == BOOLEAN_TYPE:
         return Const(random.choice(["true", "false"]), type=const_type)
 
-    if const_type == "String":
+    if const_type == STRING_TYPE:
         length = random.randint(0, 20)
         return Const('"' + gen_random_string(length) + '"', type=const_type)
 

--- a/yinyang/src/mutators/SemanticFusion/VariableFusion.py
+++ b/yinyang/src/mutators/SemanticFusion/VariableFusion.py
@@ -28,7 +28,13 @@ import string
 from yinyang.src.parsing.Ast import (
     Const, Var, Expr, Assert, DeclareConst, DeclareFun, Script
 )
-from yinyang.src.parsing.Types import BITVECTOR_TYPE, BOOLEAN_TYPE, INTEGER_TYPE, REAL_TYPE, STRING_TYPE
+from yinyang.src.parsing.Types import (
+    BITVECTOR_TYPE,
+    BOOLEAN_TYPE,
+    INTEGER_TYPE,
+    REAL_TYPE,
+    STRING_TYPE,
+)
 
 
 constant_name_pattern = re.compile(r"^c[0-9]*$")

--- a/yinyang/src/parsing/Types.py
+++ b/yinyang/src/parsing/Types.py
@@ -20,6 +20,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from ffg.gen.gen_configuration import (
+    BOOLEAN_OPTION,
+    REAL_OPTION,
+    INT_OPTION,
+    STRING_OPTION,
+    BITVECTOR_OPTION
+)
+
 BOOLEAN_TYPE = "Bool"
 REAL_TYPE = "Real"
 INTEGER_TYPE = "Int"
@@ -37,6 +45,22 @@ TYPES = [
     REGEXP_TYPE,
     ROUNDINGMODE_TYPE,
 ]
+
+
+def type2ffg(typ):
+    if typ == BOOLEAN_TYPE:
+        return BOOLEAN_OPTION
+    elif typ == REAL_TYPE:
+        return REAL_OPTION
+    elif typ == INTEGER_TYPE:
+        return INT_OPTION
+    elif typ == STRING_TYPE:
+        return STRING_OPTION
+    elif isinstance(typ, BITVECTOR_OPTION):
+        # TODO: manage also the size
+        return BITVECTOR_OPTION
+    else:
+        raise ValueError(f"The type {typ} is not supported by the generator")
 
 
 def sort2type(sort):


### PR DESCRIPTION
Add the command line option `--keep-seeds` (`-k`) with default value `True`. 
When set to `False`, scratch files will not be kept in the scratch folder after the Fuzzer executes, but the files will be created anyway.

Add command line option for Semantic Fusion to generate fusion functions with the fusion function generator: https://github.com/nicdard/fusion-function-generator/pull/78
Use --generate-functions option (int value, the size of the functions) to generate a fusion function on demand to perform the fuse step of semantic fusion.