### PR TITLE
Fixing scoping bug 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
     - name: regression
       run: |
         python tests/regression/issue42.py
+        cd tests/regression && python scoping_bug.py
     - name: code style and static analysis with flake 
       run: |
         bin/checkstyle.sh

--- a/tests/regression/scoping_bug.py
+++ b/tests/regression/scoping_bug.py
@@ -19,17 +19,19 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
 import sys
 
 sys.path.append("../../")
 
 from yinyang.src.parsing.Parse import parse_str
 
-script, _  = parse_str("""\
+script, _ = parse_str("""\
 (declare-fun t () String)
 (declare-fun t1 () String)
 (declare-fun t2 () String)
-(assert (forall ((t1 String) (t2 String))(=> (= (str.++ t1 t2) t) (= (= t1 s) false))))
-(check-sat)""",silent=False)
+(assert (forall ((t1 String) (t2 String))(=> (= (str.++ t1 t2) t)
+        (= (= t1 s) false))))
+(check-sat)""")
 script.prefix_vars("scr1_")
 assert("(str.++ t1 t2)" in script.__str__())

--- a/tests/regression/scoping_bug.py
+++ b/tests/regression/scoping_bug.py
@@ -1,0 +1,35 @@
+# MIT License
+#
+# Copyright (c) [2020 - 2021] The yinyang authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import sys
+
+sys.path.append("../../")
+
+from yinyang.src.parsing.Parse import parse_str
+
+script, _  = parse_str("""\
+(declare-fun t () String)
+(declare-fun t1 () String)
+(declare-fun t2 () String)
+(assert (forall ((t1 String) (t2 String))(=> (= (str.++ t1 t2) t) (= (= t1 s) false))))
+(check-sat)""",silent=False)
+script.prefix_vars("scr1_")
+assert("(str.++ t1 t2)" in script.__str__())

--- a/tests/regression/scoping_bug.py
+++ b/tests/regression/scoping_bug.py
@@ -34,4 +34,4 @@ script, _ = parse_str("""\
         (= (= t1 s) false))))
 (check-sat)""")
 script.prefix_vars("scr1_")
-assert("(str.++ t1 t2)" in script.__str__())
+assert ("(str.++ t1 t2)" in script.__str__())

--- a/yinyang/config/OpfuzzHelptext.py
+++ b/yinyang/config/OpfuzzHelptext.py
@@ -29,7 +29,7 @@ header = (
     + "]"
 )
 
-usage = """ opfuzz [options] solver_clis seed_file   [optionally, more seed files]
+usage = """opfuzz [options] solver_clis seed_file [optionally, more seed files]
        opfuzz [options] solver_clis seed_folder [optionally, more seed folders]
        solver_clis := "solver_cli1;solver_cli2;...;solver_clik"
 """

--- a/yinyang/src/mutators/GenTypeAwareMutation/Util.py
+++ b/yinyang/src/mutators/GenTypeAwareMutation/Util.py
@@ -130,7 +130,7 @@ def local_defs(term, local):
     term: term object
     local: list of local variables defined in the parent terms
 
-    :returns: list of local vairables to be considered within the term
+    :returns: list of local variables to be considered within the term
     """
     term = term.parent
     if term:

--- a/yinyang/src/parsing/Ast.py
+++ b/yinyang/src/parsing/Ast.py
@@ -63,8 +63,8 @@ class Script:
             return
         if e.quantifier:
             for var in list(global_vars):
-                for quantified_var in e.quantified_vars:
-                    if var == quantified_var[0]:
+                for quantified_var in e.quantified_vars[0]:
+                    if var == quantified_var:
                         global_vars.pop(var)
 
         if e.var_binders:


### PR DESCRIPTION
Issue with quantifiers of the form `(forall ((t1 String) (t2 String)) expr` in which case t2 would be considered free variable leading to an unsoundness in unsat fusion.