### PR TITLE
fix: make sure there are still available variables during allocation

### DIFF
--- a/yinyang/src/mutators/SemanticFusion/Util.py
+++ b/yinyang/src/mutators/SemanticFusion/Util.py
@@ -179,7 +179,10 @@ def random_var_triplets(global_vars1, global_vars2, templates):
                     # where we pick, to try to equally distribute the
                     # variables in the seed formulas.
                     map_index = (map_index + 1) % map_length
-                    if (sort in maps[map_index]):
+                    # We need at least a variable to be available 
+                    # for allocation
+                    if (sort in maps[map_index] 
+                            and len(maps[map_index][sort]) > 0):
                         break
                     if starting == map_index:
                         # This template cannot be instantiated with


### PR DESCRIPTION
A bug was recently introduced in the algorithm which is responsible check whether a template can be allocated to a selection of seeds. The problem arise when the variables from a seed of a certain sort have been already used and therefore the map contains an empty list. In that case the algorithm fails to select a new variable from the seed variable list to assign to the current template variable which is trying to allocate with the message: `Cannot choose from an empty sequence`