### PR TITLE
Add --seed option to typefuzz for reproducible runs

### DIFF
--- a/bin/typefuzz
+++ b/bin/typefuzz
@@ -25,6 +25,7 @@ import os
 import sys
 import signal
 import inspect
+import random
 from pathlib import Path
 
 path = Path(__file__)
@@ -81,6 +82,8 @@ def main():
 
     else:
         args = run_checks(parser, "typefuzz")
+        if args.seed is not None:
+            random.seed(args.seed)
         try:
             fuzzer = Fuzzer(args, "typefuzz")
 

--- a/yinyang/config/TypefuzzHelptext.py
+++ b/yinyang/config/TypefuzzHelptext.py
@@ -121,6 +121,8 @@ options:
     -c <file>, --config <file>
             set custom config file. 
             (default: yinyang/config/typefuzz_config.txt)
+    --seed <N>
+            random seed for reproducible runs
     -L <bytes>, --limit <bytes>
             file size limit on seed formula in bytes (default: 100000)
     -k, --keep-mutants  do not delete scratch files

--- a/yinyang/src/base/ArgumentParser.py
+++ b/yinyang/src/base/ArgumentParser.py
@@ -164,6 +164,13 @@ def add_typefuzz_args(parser, rootpath, current_dir):
         metavar="path_to_file",
         default=rootpath + "/yinyang/config/typefuzz_config.txt",
     )
+    parser.add_argument(
+        "--seed",
+        metavar="<N>",
+        type=int,
+        default=None,
+        help="random seed for reproducible runs",
+    )
 
 
 def add_yinyang_args(parser, rootpath, current_dir):


### PR DESCRIPTION
- Add --seed command-line argument to set random seed
- Initialize random seed early in execution if provided
- Update help text to document the new option
- Enables reproducible fuzzing runs for evaluation and comparison